### PR TITLE
(mask) revert the change of mask

### DIFF
--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -43,8 +43,10 @@ Furthermore for fitting to an observation an observation is required:
     * Uncertainties uncs
         >>> sme.uncs = Uncertainties
     * Mask mask
-        >>> # The mask values are: 0: bad pixel, 1: line pixel, 2: continuum pixel
-        >>> sme.mask = np.ones(len(Spectrum))
+        >>> # The mask values are: 0: bad pixel, 1: line pixel, 2: continuum pixel, 4: vrad pixel
+        >>> # The masks are additive, i.e., you can set mask value to 5 for line and vrad pixel.
+        >>> # Note that the dtype of sme.mask must be int.
+        >>> sme.mask = np.ones(len(Spectrum), dtype=int)
     * radial velocity and continuum flags
         >>> # possible values are: "each", "whole", "fix", "none"
         >>> # "each": Each segment is fitted individually

--- a/src/pysme/sme.py
+++ b/src/pysme/sme.py
@@ -606,19 +606,19 @@ class SME_Structure(Parameters):
     def mask_line(self):
         if self.mask is None:
             return None
-        return self.mask == MASK_VALUES.LINE
+        return (self.mask & MASK_VALUES.LINE) != 0
 
     @property
     def mask_cont(self):
         if self.mask is None:
             return None
-        return self.mask == MASK_VALUES.CONT
+        return (self.mask & MASK_VALUES.LINE) != 0
 
     @property
     def mask_vrad(self):
         if self.mask is None:
             return None
-        return self.mask == MASK_VALUES.VRAD
+        return (self.mask & MASK_VALUES.VRAD) != 0
 
     @property
     def cscale_degree(self):


### PR DESCRIPTION
The spectral mask function is working so it is reverted. Additional description on how to use it added to doc-quickstart. 